### PR TITLE
Hotfix fsu 158

### DIFF
--- a/src/Services/ResponseService.php
+++ b/src/Services/ResponseService.php
@@ -72,7 +72,7 @@ class ResponseService
             [
                 'results' => $result,
                 'filter_options' => $filters,
-                'total_results' => $data->totalResults(),
+                'total_results' => (config('railcontent.filter_version','') == 'V2') ? $data->totalLessons() : $data->totalResults(),
             ]
         ))->toJsonResponse();
     }

--- a/src/Services/ResponseService.php
+++ b/src/Services/ResponseService.php
@@ -44,15 +44,18 @@ class ResponseService
                     array_unshift($filters[$key], 'All');
                 }
             }
-            if(!in_array($key, ContentRepository::$catalogMetaAllowableFilters ?? ['instructor', 'topic', 'style', 'artist'])){
+            if (!in_array(
+                $key,
+                ContentRepository::$catalogMetaAllowableFilters ?? ['instructor', 'topic', 'style', 'artist']
+            )) {
                 unset($filters[$key]);
             }
-            if(in_array('progress', ContentRepository::$catalogMetaAllowableFilters ?? [])){
-                $filters['progress'] = ['All','In Progress', 'Completed'];
+            if (in_array('progress', ContentRepository::$catalogMetaAllowableFilters ?? [])) {
+                $filters['progress'] = ['All', 'In Progress', 'Completed'];
             }
         }
 
-        if(in_array('difficulty', ContentRepository::$catalogMetaAllowableFilters ?? [])){
+        if (in_array('difficulty', ContentRepository::$catalogMetaAllowableFilters ?? [])) {
             $filters['showSkillLevel'] = true;
         }
 
@@ -60,7 +63,7 @@ class ResponseService
             $filters = ['content_type' => ['coach-stream']];
         }
 
-        if($request->has('old_style')){
+        if ($request->has('old_style')) {
             $result = $data->results();
         } else {
             $result = (new CatalogueTransformer())->transform($data->results());
@@ -68,13 +71,13 @@ class ResponseService
             $filters = (new FilterOptionsTransformer())->transform($filters);
         }
 
-        return (new ContentFilterResultsEntity(
-            [
-                'results' => $result,
-                'filter_options' => $filters,
-                'total_results' => (config('railcontent.filter_version','') == 'V2') ? $data->totalLessons() : $data->totalResults(),
-            ]
-        ))->toJsonResponse();
+        return (new ContentFilterResultsEntity([
+                                                   'results' => $result,
+                                                   'filter_options' => $filters,
+                                                   'total_results' => (config('railcontent.filter_version', '') ==
+                                                       'V2') ? $data->totalLessons() :
+                                                       $data->totalResults(),
+                                               ]))->toJsonResponse();
     }
 
     public static function content($data)
@@ -88,7 +91,7 @@ class ResponseService
 
     public static function scheduleContent($data)
     {
-        if(!config('musora-api.api.version')) {
+        if (!config('musora-api.api.version')) {
             return Fractal::create()
                 ->collection($data)
                 ->transformWith(ScheduledContentTransformer::class)
@@ -96,14 +99,11 @@ class ResponseService
                 ->toArray();
         }
 
-        return (new ContentFilterResultsEntity(
-            [
-                'results' => $data,
-                'filter_options' => [],
-                'total_results' => count($data),
-            ]
-        ))->toJsonResponse();
-
+        return (new ContentFilterResultsEntity([
+                                                   'results' => $data,
+                                                   'filter_options' => [],
+                                                   'total_results' => count($data),
+                                               ]))->toJsonResponse();
     }
 
     public static function live($data)
@@ -147,21 +147,18 @@ class ResponseService
             }
         }
 
-        if($request->has('old_style')){
+        if ($request->has('old_style')) {
             $result = $data->results();
         } else {
             $result = (new PlaylistsItemTransformer())->transform($data->results());
-
             //$filters = (new FilterOptionsTransformer())->transform($filters);
         }
 
-        return (new ContentFilterResultsEntity(
-            [
-                'results' => $result,
-                'filter_options' => $filters,
-                'total_results' => $data->totalResults(),
-            ]
-        ))->toJsonResponse();
+        return (new ContentFilterResultsEntity([
+                                                   'results' => $result,
+                                                   'filter_options' => $filters,
+                                                   'total_results' => $data->totalResults(),
+                                               ]))->toJsonResponse();
     }
 
     /**
@@ -172,7 +169,7 @@ class ResponseService
     {
         return Fractal::create()
             ->item($data)
-           ->transformWith(UserDataTransformer::class)
+            ->transformWith(UserDataTransformer::class)
             ->serializeWith(DataSerializer::class)
             ->toArray();
     }


### PR DESCRIPTION
[FSU-158](https://musoraproduct.myjetbrains.com/youtrack/issue/FSU-158/MA-Filter-Results-button-when-filtering-collection-carousels
)

The button "Show # Results" from mobile app should always show the total number of lessons on all tabs. Now it show the number of groups if we are on Artist/Genre/Instructor tab

The **total_results** var from the filter content response is used for the mobile app only to show the text on the button. The mobile app do not use the **total_results**  param for pagination or other logic. I decided to provide the number of lessons in the **total_results** to avoid new builds on the app.

You can use for testing the build https://app.bitrise.io/build/1347ee46-25db-4490-a07b-11dbeeb79424?tab=artifacts or
Postman endpoints: https://red-shadow-611407.postman.co/workspace/Team-Workspace~38bb093f-0978-4a83-8423-944a3c78fd51/request/9725390-dd5bbb86-c056-43d1-916f-12a7869d989a