### PR TITLE
Add draft status packs for admin users

### DIFF
--- a/src/Controllers/PacksController.php
+++ b/src/Controllers/PacksController.php
@@ -104,9 +104,11 @@ class PacksController extends Controller
      */
     public function showAllPacks(Request $request)
     {
-        ModeDecoratorBase::$decorationMode = DecoratorInterface::DECORATION_MODE_MINIMUM;
+        $adminUser = $request->user()?->isAdmin() ?? false;
+        $extraContentStatus = $adminUser ? [ContentService::STATUS_DRAFT] : [];
 
-        ContentRepository::$availableContentStatues = [ContentService::STATUS_PUBLISHED];
+        ModeDecoratorBase::$decorationMode = DecoratorInterface::DECORATION_MODE_MINIMUM;
+        ContentRepository::$availableContentStatues = array_merge([ContentService::STATUS_PUBLISHED], $extraContentStatus);
         ContentRepository::$pullFutureContent = false;
         ContentRepository::$getEnrollmentContent = false;
 


### PR DESCRIPTION
Based on [this](https://musoraworkspace.slack.com/archives/C02L6GWEASV/p1723575908821899) slack thread, this adds the draft status packs for admin users. 